### PR TITLE
Adds customizable range min and max values to Size control

### DIFF
--- a/js/controls/size.js
+++ b/js/controls/size.js
@@ -4,7 +4,11 @@ DrawingBoard.Control.Size = DrawingBoard.Control.extend({
 
 	defaults: {
 		type: "auto",
-		dropdownValues: [1, 3, 6, 10, 20, 30, 40, 50]
+		dropdownValues: [1, 3, 6, 10, 20, 30, 40, 50],
+		range: {
+			min: 1,
+			max: 50
+		}
 	},
 
 	types: ['dropdown', 'range'],
@@ -52,10 +56,14 @@ DrawingBoard.Control.Size = DrawingBoard.Control.extend({
 
 	_rangeTemplate: function() {
 		var tpl = '<div class="drawing-board-control-inner" title="{{size}}">' +
-			'<input type="range" min="1" max="50" value="{{size}}" step="1" class="drawing-board-control-size-range-input">' +
+			'<input type="range" min="{{min}}" max="{{max}}" value="{{size}}" step="1" class="drawing-board-control-size-range-input">' +
 			'<span class="drawing-board-control-size-range-current"></span>' +
 			'</div>';
-		return DrawingBoard.Utils.tpl(tpl, { size: this.board.opts.size });
+		return DrawingBoard.Utils.tpl(tpl, {
+			min: this.opts.range.min,
+			max: this.opts.range.max,
+			size: this.board.opts.size
+		});
 	},
 
 	_dropdownTemplate: function() {


### PR DESCRIPTION
Allows clients to customize the smallest and largest possible pen sizes
that users can select using the range slider.

``` javascript
var board = new DrawingBoard.Board(board.id, {
  size: 5,
  controls: [
    "Color",
    "DrawingMode",
    {
      Size: {
        range: {
          min: 5,
          max: 50
        }
      }
    },
  "Navigation"
  ]
});
```
