### PR TITLE
Fixes issue #29

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -3,6 +3,7 @@
 	"version": "0.4.4",
 	"main": ["dist/drawingboard.js", "dist/drawingboard.css"],
 	"dependencies": {
-		"jquery": "*"
+		"jquery": "*",
+		"simple-undo": "*"
 	}
 }

--- a/example/index.html
+++ b/example/index.html
@@ -120,6 +120,7 @@
 
 		<!-- jquery is required - zepto might do the trick too -->
 		<script src="../components/jquery/jquery.min.js"></script>
+		<script src="../bower_components/simple-undo/lib/simple-undo.js"></script>
 
 		<!-- in a production environment, just include the minified script. It contains the board and the default controls (size, nav, colors, download): -->
 		<!--<script src="../dist/drawingboard.min.js"></script>-->

--- a/js/board.js
+++ b/js/board.js
@@ -65,7 +65,7 @@ DrawingBoard.Board = function(id, opts) {
 	//set board's size after the controls div is added
 	this.resize();
 	//reset the board to take all resized space
-	this.reset({ webStorage: false, history: true, background: true });
+	this.reset({ webStorage: false, history: false, background: true });
 	this.restoreWebStorage();
 	this.initDropEvents();
 	this.initDrawEvents();
@@ -120,7 +120,9 @@ DrawingBoard.Board.prototype = {
 
 		this.setMode('pencil');
 
-		if (opts.background) this.resetBackground(this.opts.background, false);
+		if (opts.background) this.resetBackground(this.opts.background, $.proxy(function() {
+			if (opts.history) this.saveHistory();
+		},this));
 
 		if (opts.color) this.setColor(opts.color);
 		if (opts.size) this.ctx.lineWidth = opts.size;
@@ -131,16 +133,17 @@ DrawingBoard.Board.prototype = {
 
 		if (opts.webStorage) this.saveWebStorage();
 
-		if (opts.history) this.saveHistory();
+		// if opts.background we already dealt with the history
+		if (opts.history && !opts.background) this.saveHistory();
 
 		this.blankCanvas = this.getImg();
 
 		this.ev.trigger('board:reset', opts);
 	},
 
-	resetBackground: function(background, historize) {
+	resetBackground: function(background, callback) {
 		background = background || this.opts.background;
-		historize = typeof historize !== "undefined" ? historize : true;
+
 		var bgIsColor = DrawingBoard.Utils.isColor(background);
 		var prevMode = this.getMode();
 		this.setMode('pencil');
@@ -148,10 +151,16 @@ DrawingBoard.Board.prototype = {
 		if (bgIsColor) {
 			this.ctx.fillStyle = background;
 			this.ctx.fillRect(0, 0, this.ctx.canvas.width, this.ctx.canvas.height);
+			this.history.initialize(this.getImg());
+			if (callback) callback();
 		} else if (background)
-			this.setImg(background);
+			this.setImg(background, {
+				callback: $.proxy(function() {
+					this.history.initialize(this.getImg());
+					if (callback) callback();
+				},this)
+			});
 		this.setMode(prevMode);
-		if (historize) this.saveHistory();
 	},
 
 	resize: function() {
@@ -260,49 +269,36 @@ DrawingBoard.Board.prototype = {
 	 */
 
 	initHistory: function() {
-		this.history = {
-			values: [],
-			position: 0
-		};
+		this.history = new SimpleUndo({
+			maxLength: 30,
+			provider: $.proxy(function(done) {
+				done(this.getImg());
+			},this),
+			onUpdate:$.proxy(function() {
+				this.ev.trigger('historyNavigation');
+			},this)
+		});
 	},
 
-	saveHistory: function () {
-		while (this.history.values.length > 30) {
-			this.history.values.shift();
-			this.history.position--;
-		}
-		if (this.history.position !== 0 && this.history.position < this.history.values.length) {
-			this.history.values = this.history.values.slice(0, this.history.position);
-			this.history.position++;
-		} else {
-			this.history.position = this.history.values.length+1;
-		}
-		this.history.values.push(this.getImg());
-		this.ev.trigger('historyNavigation', this.history.position);
+	saveHistory: function() {
+		this.history.save();
 	},
 
-	_goThroughHistory: function(goForth) {
-		if ((goForth && this.history.position == this.history.values.length) ||
-			(!goForth && this.history.position == 1))
-			return;
-		var pos = goForth ? this.history.position+1 : this.history.position-1;
-		if (this.history.values.length && this.history.values[pos-1] !== undefined) {
-			this.history.position = pos;
-			this.setImg(this.history.values[pos-1]);
-		}
-		this.ev.trigger('historyNavigation', pos);
-		this.saveWebStorage();
+	restoreHistory: function(image) {
+		this.setImg(image, {
+			callback: $.proxy(function() {
+				this.saveWebStorage();
+			},this)
+		});
 	},
 
 	goBackInHistory: function() {
-		this._goThroughHistory(false);
+		this.history.undo($.proxy(this.restoreHistory,this));
 	},
 
 	goForthInHistory: function() {
-		this._goThroughHistory(true);
+		this.history.redo($.proxy(this.restoreHistory,this));
 	},
-
-
 
 	/**
 	 * Image methods: you can directly put an image on the canvas, get it in base64 data url or start a download
@@ -310,8 +306,10 @@ DrawingBoard.Board.prototype = {
 
 	setImg: function(src, opts) {
 		opts = $.extend({
-			stretch: this.opts.stretchImg
+			stretch: this.opts.stretchImg,
+			callback: null
 		}, opts);
+
 		var ctx = this.ctx;
 		var img = new Image();
 		var oldGCO = ctx.globalCompositeOperation;
@@ -326,6 +324,10 @@ DrawingBoard.Board.prototype = {
 			}
 
 			ctx.globalCompositeOperation = oldGCO;
+			
+			if (opts.callback) {
+				opts.callback();
+			}
 		};
 		img.src = src;
 	},
@@ -398,10 +400,13 @@ DrawingBoard.Board.prototype = {
 		var fr = new FileReader();
 		fr.readAsDataURL(files[0]);
 		fr.onload = $.proxy(function(ev) {
-			this.setImg(ev.target.result);
+			this.setImg(ev.target.result, {
+				callback: $.proxy(function() {
+					this.saveHistory();		
+				},this)
+			});
 			this.ev.trigger('board:imageDropped', ev.target.result);
 			this.ev.trigger('board:userAction');
-			this.saveHistory();
 		}, this);
 	},
 

--- a/js/controls/navigation.js
+++ b/js/controls/navigation.js
@@ -17,30 +17,24 @@ DrawingBoard.Control.Navigation = DrawingBoard.Control.extend({
 
 		if (this.opts.back) {
 			var $back = this.$el.find('.drawing-board-control-navigation-back');
-			this.board.ev.bind('historyNavigation', $.proxy(function(pos) {
-				if (pos === 1)
-					$back.attr('disabled', 'disabled');
-				else
-					$back.removeAttr('disabled');
-			}, this));
+			this.board.ev.bind('historyNavigation', $.proxy(this.updateBack, this, $back));
 			this.$el.on('click', '.drawing-board-control-navigation-back', $.proxy(function(e) {
 				this.board.goBackInHistory();
 				e.preventDefault();
 			}, this));
+			
+			this.updateBack($back);
 		}
 
 		if (this.opts.forward) {
 			var $forward = this.$el.find('.drawing-board-control-navigation-forward');
-			this.board.ev.bind('historyNavigation', $.proxy(function(pos) {
-				if (pos === this.board.history.values.length)
-					$forward.attr('disabled', 'disabled');
-				else
-					$forward.removeAttr('disabled');
-			}, this));
+			this.board.ev.bind('historyNavigation', $.proxy(this.updateForward, this, $forward));
 			this.$el.on('click', '.drawing-board-control-navigation-forward', $.proxy(function(e) {
 				this.board.goForthInHistory();
 				e.preventDefault();
 			}, this));
+			
+			this.updateForward($forward);
 		}
 
 		if (this.opts.reset) {
@@ -48,6 +42,22 @@ DrawingBoard.Control.Navigation = DrawingBoard.Control.extend({
 				this.board.reset({ background: true });
 				e.preventDefault();
 			}, this));
+		}
+	},
+	
+	updateBack: function($back) {
+		if (this.board.history.canUndo()) {
+			$back.removeAttr('disabled');
+		} else {
+			$back.attr('disabled','disabled');
+		}
+	},
+	
+	updateForward: function($forward) {
+		if (this.board.history.canRedo()) {
+			$forward.removeAttr('disabled');
+		} else {
+			$forward.attr('disabled','disabled');
 		}
 	}
 });


### PR DESCRIPTION
The fix consists in basically two things:
* _externalizing the "history" part_. I created a very simple component called [simple-undo](https://github.com/mattjmattj/simple-undo) to do so and I added it as bower dependency. I then integrated it everywhere in `js/board.js` and `js/controls/navigation.js`. The major thing I intended to do with externalizing the history part was to fix some strange behaviors implied by the direct use of the history position, in navigation for example, and the lack of an "initial state". Please notice that this integration induces two important changes : 
 * history event `historyNavigation` does not send the current position anymore. 
 * resetting the background does not save a new state in history anymore, but saves the initial state
* _fixing DrawingBoard.Board.setImg_ `DrawingBoard.Board.setImg` performs an asynchronous treatment. Indeed it loads an image and then uses it as a background. Calling `setImg`and then callling `getImg` will not get the expected image. So I added a callback parameter in setImg and changed wherever something was called after a call to setImg