### PR TITLE
Hack to try and fix the anti-aliasing issue

### DIFF
--- a/js/board.js
+++ b/js/board.js
@@ -488,10 +488,10 @@ DrawingBoard.Board.prototype = {
 		var maxY = img.height - 1;
 
 		while ((pixel = queue.pop())) {
+			img.data[pixel[INDEX]] = r;
+			img.data[pixel[INDEX] + 1] = g;
+			img.data[pixel[INDEX] + 2] = b;
 			if (DrawingBoard.Utils.compareColors(pixel[COLOR], startColor, tolerance)) {
-				img.data[pixel[INDEX]] = r;
-				img.data[pixel[INDEX] + 1] = g;
-				img.data[pixel[INDEX] + 2] = b;
 				if (pixel[X] > 0) // west
 					queue.push(DrawingBoard.Utils.pixelAt(img, pixel[X] - 1, pixel[Y]));
 				if (pixel[X] < maxX) // east


### PR DESCRIPTION
DrawingBoard.Board.fill tries to fill an area with the selected stroke color. The problem
is that drawn lines are anti-aliased, causing the lines not to be of a unique, plain color.
When "fill" iterates on the pixels composing the area to fill, it will stop when finding
a pixel of a different color; but this pixel is part of the anti-aliasing gradient, not
the actual line.

This anti-aliasing cannot be disabled.

One possible way of solving the problem would be to draw lines at pixel level, using putImageData, 
but it would be a real performance killer.

The hack proposed here is, instead of stopping iterating pixels too early and leaving part
of the antialiasing gradient, to make one more step at the end.

This causes the filled area to be at most 1 pixel too big, but solves the original problem
most of the time. Note that this hack WILL erase the border of the filled area if that
border is only a 1-pixel-wide line.
