### PR TITLE
Fixes the path to jquery.min.js

### DIFF
--- a/example/index.html
+++ b/example/index.html
@@ -119,7 +119,7 @@
 		</div>
 
 		<!-- jquery is required - zepto might do the trick too -->
-		<script src="../components/jquery/jquery.min.js"></script>
+		<script src="../bower_components/jquery/dist/jquery.min.js"></script>
 
 		<!-- in a production environment, just include the minified script. It contains the board and the default controls (size, nav, colors, download): -->
 		<!--<script src="../dist/drawingboard.min.js"></script>-->


### PR DESCRIPTION
jquery.min.js, if installed through bower, is now located in bower_components/jquery/dist/

this commit changes the path in example/index.html