### PR TITLE
Fixes npm error "Invalid version"

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "drawingboard.js",
-	"version": "1.3.3.7",
+	"version": "0.4.4",
 	"devDependencies": {
 		"grunt": "~0.4.1",
 		"grunt-contrib-concat": "~0.3.0",


### PR DESCRIPTION
This commit fixes an error when executing npm install.
npm complains about a non-semver version and stops.