### PR TITLE
Use latests grunt-contrib-uglify

### DIFF
--- a/js/board.js
+++ b/js/board.js
@@ -22,9 +22,14 @@ DrawingBoard.Board = function(id, opts) {
 	this.ev = new DrawingBoard.Utils.MicroEvent();
 
 	this.id = id;
-	this.$el = $(document.getElementById(id));
-	if (!this.$el.length)
-		return false;
+
+    if(id instanceof jQuery){
+        this.$el = id; 
+    } else {
+        this.$el = $(document.getElementById(id));
+        if (!this.$el.length)
+            return false;
+    }
 
 	var tpl = '<div class="drawing-board-canvas-wrapper"></canvas><canvas class="drawing-board-canvas"></canvas><div class="drawing-board-cursor drawing-board-utils-hidden"></div></div>';
 	if (this.opts.controlsPosition.indexOf("bottom") > -1) tpl += '<div class="drawing-board-controls"></div>';

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
 	"devDependencies": {
 		"grunt": "~0.4.1",
 		"grunt-contrib-concat": "~0.3.0",
-		"grunt-contrib-uglify": "~0.2.2",
+		"grunt-contrib-uglify": "~0.11.1",
 		"grunt-contrib-cssmin": "~0.6.1"
 	}
 }


### PR DESCRIPTION
Uglify seems to be outdated and grunt throws warning.

```Gzipped:  Warning: Cannot assign to read only property 'subarray' of /* drawingboard.js v0.4.6 -...```