### PR TITLE
Updated grunt-contrib-uglifyer to 0.11.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
 	"devDependencies": {
 		"grunt": "~0.4.1",
 		"grunt-contrib-concat": "~0.3.0",
-		"grunt-contrib-uglify": "~0.2.2",
+		"grunt-contrib-uglify": "~0.11.1",
 		"grunt-contrib-cssmin": "~0.6.1"
 	}
 }


### PR DESCRIPTION
Uglify seems to be outdated and grunt throws warning.

```Gzipped: Warning: Cannot assign to read only property 'subarray' of /* drawingboard.js v0.4.6 -...```