### PR TITLE
Load jQuery from an https site

### DIFF
--- a/index.html
+++ b/index.html
@@ -98,7 +98,7 @@
 		</div>
 
 		<!-- jquery is required - zepto might do the trick too -->
-		<script src="http://code.jquery.com/jquery-1.10.1.min.js"></script>
+		<script src="https://code.jquery.com/jquery-1.10.1.min.js"></script>
 
 		<!-- in a production environment, just include the minified script. It contains the board and the default controls (size, nav, colors, download): -->
 		<script src="bower_components/drawingboard.js/dist/drawingboard.min.js"></script>


### PR DESCRIPTION
Chrome prevents loading http from https. This dependency can be updated to https